### PR TITLE
Move package dependency out of NPM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "atom-linter": "^8.0.0",
-    "atom-package-deps": "^4.0.1",
-    "language-gettext": "*"
+    "atom-package-deps": "^4.0.1"
   },
   "package-deps": [
-    "linter"
+    "linter",
+    "language-gettext"
   ],
   "providedServices": {
     "linter": {


### PR DESCRIPTION
`language-gettext` is an Atom package, not NPM package. Move the declaration of it as a dependency over into the proper list.