### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/linter-gettext.js
+++ b/lib/linter-gettext.js
@@ -8,11 +8,11 @@ export default {
     }
   },
 
-  activate: () => {
+  activate() {
     require('atom-package-deps').install('linter-gettext');
   },
 
-  provideLinter: () => {
+  provideLinter() {
     const helpers = require('atom-linter');
     const regex = String.raw`(?<file>[^:]+):(?<line>\d+):(?:(?<col>\d+):)? ((?<type>\w+): (?<message>.+)|(?<message>.+))`;
     return {


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.